### PR TITLE
Move race list panel to right side

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -199,7 +199,7 @@ body {
   width: 260px;
   flex-shrink: 0;
   background: var(--surface);
-  border-right: 1px solid var(--border);
+  border-left: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -306,7 +306,7 @@ body {
   width: 280px;
   flex-shrink: 0;
   background: var(--surface);
-  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
   overflow-y: auto;
   scrollbar-width: thin;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,12 +25,12 @@ function App() {
       <Header />
       <NewsTicker />
       <div className="main-layout">
-        <Sidebar />
+        <SessionPanel />
         <div className="globe-wrapper">
           <GlobeCanvas touring={touring} onTourChange={handleTourChange} />
           <TourButton touring={touring} onToggle={handleTourToggle} />
         </div>
-        <SessionPanel />
+        <Sidebar />
       </div>
       <button className="info-btn" onClick={() => setInfoPanelOpen(true)}>ⓘ</button>
       <InfoPanel open={infoPanelOpen} onClose={() => setInfoPanelOpen(false)} />


### PR DESCRIPTION
## Summary
- Swaps Sidebar (race list) and SessionPanel positions in the main layout
- Race list now on the right, session details on the left
- Updated CSS borders to match new positions

Closes #1

## Test plan
- [ ] Verify race list appears on the right side of the globe
- [ ] Verify session panel appears on the left side of the globe
- [ ] Verify mobile/responsive layout still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)