### PR TITLE
Mark cancelled races due to Middle East conflict

### DIFF
--- a/backend/src/main/java/com/gridpulse/api/model/Race.java
+++ b/backend/src/main/java/com/gridpulse/api/model/Race.java
@@ -26,6 +26,7 @@ public class Race {
     private Map<String, String> indySessions;
     private Map<String, String> wecSessions;
     private Map<String, String> wrcSessions;
+    private boolean cancelled;
 
     public Race() {}
 
@@ -79,4 +80,7 @@ public class Race {
 
     public Map<String, String> getWrcSessions() { return wrcSessions; }
     public void setWrcSessions(Map<String, String> wrcSessions) { this.wrcSessions = wrcSessions; }
+
+    public boolean isCancelled() { return cancelled; }
+    public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
 }

--- a/backend/src/main/resources/seed/races.json
+++ b/backend/src/main/resources/seed/races.json
@@ -111,7 +111,8 @@
       "quali": "2026-04-10T11:30Z",
       "sprint": "2026-04-11T08:30Z",
       "feature": "2026-04-12T07:30Z"
-    }
+    },
+    "cancelled": true
   },
   {
     "id": "jeddah-corniche-circuit",
@@ -122,7 +123,8 @@
     "series": [
       "f1",
       "f2",
-      "f3"
+      "f3",
+      "f1a"
     ],
     "timezone": "Asia/Riyadh",
     "lat": 21.54,
@@ -145,6 +147,12 @@
       "quali": "2026-04-17T15:00Z",
       "sprint": "2026-04-18T11:15Z",
       "feature": "2026-04-18T23:45Z"
+    },
+    "cancelled": true,
+    "f1aSessions": {
+      "quali": "2026-04-17T10:00Z",
+      "race1": "2026-04-18T10:00Z",
+      "race2": "2026-04-19T10:00Z"
     }
   },
   {
@@ -284,7 +292,8 @@
     "series": [
       "f1",
       "f2",
-      "f3"
+      "f3",
+      "f1a"
     ],
     "timezone": "America/Toronto",
     "lat": 45.5,
@@ -307,6 +316,11 @@
       "quali": "2026-06-12T19:00Z",
       "sprint": "2026-06-13T14:30Z",
       "feature": "2026-06-13T22:45Z"
+    },
+    "f1aSessions": {
+      "quali": "2026-05-22T15:00Z",
+      "race1": "2026-05-23T15:00Z",
+      "race2": "2026-05-24T14:00Z"
     }
   },
   {
@@ -352,7 +366,8 @@
     "series": [
       "f1",
       "f2",
-      "f3"
+      "f3",
+      "f1a"
     ],
     "timezone": "Europe/London",
     "lat": 52.07,
@@ -375,6 +390,11 @@
       "quali": "2026-07-03T12:30Z",
       "sprint": "2026-07-04T08:30Z",
       "feature": "2026-07-04T22:45Z"
+    },
+    "f1aSessions": {
+      "quali": "2026-07-03T10:00Z",
+      "race1": "2026-07-04T10:00Z",
+      "race2": "2026-07-05T09:30Z"
     }
   },
   {
@@ -452,7 +472,8 @@
     "region": "Dutch GP",
     "round": 15,
     "series": [
-      "f1"
+      "f1",
+      "f1a"
     ],
     "timezone": "Europe/Amsterdam",
     "lat": 52.39,
@@ -463,6 +484,11 @@
       "fp3": "2026-08-29T09:30Z",
       "quali": "2026-08-29T13:00Z",
       "race": "2026-08-30T13:00Z"
+    },
+    "f1aSessions": {
+      "quali": "2026-08-21T10:00Z",
+      "race1": "2026-08-22T10:00Z",
+      "race2": "2026-08-23T09:30Z"
     }
   },
   {
@@ -617,7 +643,7 @@
     "id": "autodromo-jose-carlos-pace",
     "city": "Autodromo Jose Carlos Pace",
     "country": "Brazil",
-    "region": "São Paulo GP",
+    "region": "S\u00e3o Paulo GP",
     "round": 21,
     "series": [
       "f1",
@@ -763,9 +789,9 @@
   },
   {
     "id": "s-o-paulo",
-    "city": "São Paulo",
+    "city": "S\u00e3o Paulo",
     "country": "Brazil",
-    "region": "São Paulo E-Prix",
+    "region": "S\u00e3o Paulo E-Prix",
     "round": "FE-2",
     "series": [
       "fe"
@@ -1173,7 +1199,8 @@
     "lng": 51.45,
     "sessions": {
       "race": "2026-01-24T13:00Z"
-    }
+    },
+    "cancelled": true
   },
   {
     "id": "sebring-international-raceway",
@@ -1195,7 +1222,7 @@
     "id": "algarve-international-circuit",
     "city": "Algarve International Circuit",
     "country": "Portugal",
-    "region": "Portimão 6 Hours",
+    "region": "Portim\u00e3o 6 Hours",
     "round": "WEC-3",
     "series": [
       "wec"
@@ -1259,7 +1286,7 @@
     "id": "interlagos-wec",
     "city": "Interlagos WEC",
     "country": "Brazil",
-    "region": "São Paulo 6 Hours",
+    "region": "S\u00e3o Paulo 6 Hours",
     "round": "WEC-7",
     "series": [
       "wec"
@@ -1305,7 +1332,7 @@
   },
   {
     "id": "ume",
-    "city": "Umeå",
+    "city": "Ume\u00e5",
     "country": "Sweden",
     "region": "Rally Sweden",
     "round": "WRC-2",
@@ -1385,7 +1412,7 @@
   },
   {
     "id": "miko-ajki",
-    "city": "Mikołajki",
+    "city": "Miko\u0142ajki",
     "country": "Poland",
     "region": "Rally Poland",
     "round": "WRC-7",
@@ -1417,7 +1444,7 @@
   },
   {
     "id": "jyv-skyl",
-    "city": "Jyväskylä",
+    "city": "Jyv\u00e4skyl\u00e4",
     "country": "Finland",
     "region": "Rally Finland",
     "round": "WRC-9",
@@ -1449,9 +1476,9 @@
   },
   {
     "id": "concepci-n",
-    "city": "Concepción",
+    "city": "Concepci\u00f3n",
     "country": "Chile",
-    "region": "Rally Chile Bio Bío",
+    "region": "Rally Chile Bio B\u00edo",
     "round": "WRC-11",
     "series": [
       "wrc"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -259,6 +259,11 @@ body {
 .ci-bottom { display: flex; gap: 8px; font-size: 0.6rem; color: var(--muted); margin-top: 2px; }
 .ci-badges { display: flex; gap: 4px; margin-top: 4px; }
 
+/* ── Cancelled races ── */
+.city-item.cancelled { opacity: 0.5; }
+.city-item.cancelled .ci-name { text-decoration: line-through; }
+.ci-cancelled { color: #ff4444 !important; font-weight: 600; letter-spacing: 0.03em; }
+
 /* ── Globe ── */
 .globe-wrapper {
   flex: 1;
@@ -352,6 +357,19 @@ body {
 }
 .sp-countdown-label { font-size: 0.55rem; color: var(--muted); text-transform: uppercase; }
 .sp-countdown-value { font-size: 1.1rem; font-weight: 500; color: var(--accent); margin-top: 2px; }
+
+.sp-cancelled-banner {
+  margin: 12px;
+  padding: 10px;
+  background: rgba(255,68,68,0.1);
+  border: 1px solid rgba(255,68,68,0.3);
+  border-radius: 6px;
+  text-align: center;
+  color: #ff4444;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+}
 
 /* ── Info Panel ── */
 .info-btn {

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -10,7 +10,7 @@ function getNextRaceForSeries(races: Race[], seriesKey: string): Race | null {
   const now = Date.now();
   return (
     races
-      .filter((r) => r.series.includes(seriesKey))
+      .filter((r) => r.series.includes(seriesKey) && !r.cancelled)
       .map((r) => {
         // Find the race session time for the primary series
         const sessionMap = seriesKey === 'f1' ? r.sessions

--- a/frontend/src/components/session/SessionPanel.tsx
+++ b/frontend/src/components/session/SessionPanel.tsx
@@ -92,6 +92,10 @@ export function SessionPanel() {
         <button className="sp-close" onClick={() => selectRace(null)}>✕</button>
       </div>
 
+      {selectedRace.cancelled && (
+        <div className="sp-cancelled-banner">{t('race_cancelled', 'CANCELLED')}</div>
+      )}
+
       <div className="sp-sessions">
         {[...grouped.entries()].map(([day, sessions]) => (
           <div key={day}>

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -20,18 +20,18 @@ export function Sidebar() {
       <div className="city-list">
         {filteredRaces.map((race) => {
           const raceTime = race.sessions?.race || race.feSessions?.race || race.indySessions?.race;
-          const daysText = raceTime ? daysUntilRace(raceTime, t) : '';
+          const daysText = race.cancelled ? t('race_cancelled', 'CANCELLED') : (raceTime ? daysUntilRace(raceTime, t) : '');
           const isActive = selectedRace?.id === race.id;
 
           return (
             <div
               key={race.id}
-              className={`city-item ${isActive ? 'active' : ''}`}
+              className={`city-item ${isActive ? 'active' : ''} ${race.cancelled ? 'cancelled' : ''}`}
               onClick={() => selectRace(race)}
             >
               <div className="ci-top">
                 <span className="ci-name">{race.region}</span>
-                <span className="ci-time">{daysText}</span>
+                <span className={`ci-time ${race.cancelled ? 'ci-cancelled' : ''}`}>{daysText}</span>
               </div>
               <div className="ci-bottom">
                 <span className="ci-round">R{race.round}</span>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,6 +16,7 @@ export interface Race {
   indySessions?: Record<string, string>;
   wecSessions?: Record<string, string>;
   wrcSessions?: Record<string, string>;
+  cancelled?: boolean;
 }
 
 export interface SeriesConfig {


### PR DESCRIPTION
## Summary
- Add `cancelled` field to Race model (backend + frontend)
- Mark Bahrain (F1/F2/F3), Jeddah (F1/F2/F3/F1A), and Qatar WEC as cancelled
- Add missing F1A rounds: Montreal, Silverstone, Zandvoort
- Cancelled races show with reduced opacity + strikethrough in sidebar, red "CANCELLED" label
- Red cancelled banner in session detail panel
- Header countdown skips cancelled races

## Test plan
- [ ] Verify Bahrain, Jeddah, Qatar WEC show as cancelled in sidebar
- [ ] Verify cancelled races have strikethrough + red "CANCELLED" label
- [ ] Verify clicking a cancelled race shows red banner in session panel
- [ ] Verify header countdown skips cancelled races for F1, F2, F3, F1A, WEC
- [ ] Verify non-cancelled races display normally

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)