### PR TITLE
Add OpenAPI documentation for backend REST API

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -47,6 +47,13 @@
             <artifactId>caffeine</artifactId>
         </dependency>
 
+        <!-- API documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+
         <!-- RSS parsing -->
         <dependency>
             <groupId>com.rometools</groupId>

--- a/backend/src/main/java/com/gridpulse/api/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/gridpulse/api/config/OpenApiConfig.java
@@ -1,0 +1,26 @@
+package com.gridpulse.api.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI gridPulseOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("GridPulse API")
+                        .description("REST API for GridPulse motorsport calendar — provides race schedules, series info, news, and translations for F1, F2, F3, F1 Academy, Formula E, IndyCar, WEC, and WRC.")
+                        .version("1.0.0")
+                        .contact(new Contact().name("GridPulse").url("https://gridpulse.csargy.co.uk")))
+                .servers(List.of(
+                        new Server().url("/").description("Current server")));
+    }
+}

--- a/backend/src/main/java/com/gridpulse/api/controller/NewsController.java
+++ b/backend/src/main/java/com/gridpulse/api/controller/NewsController.java
@@ -2,6 +2,8 @@ package com.gridpulse.api.controller;
 
 import com.gridpulse.api.model.NewsItem;
 import com.gridpulse.api.service.NewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,6 +12,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/news")
+@Tag(name = "News", description = "Motorsport news from RSS feeds")
 public class NewsController {
 
     private final NewsService newsService;
@@ -19,6 +22,7 @@ public class NewsController {
     }
 
     @GetMapping
+    @Operation(summary = "Get news", description = "Returns latest motorsport news aggregated from RSS feeds")
     public List<NewsItem> getNews() {
         return newsService.getNews();
     }

--- a/backend/src/main/java/com/gridpulse/api/controller/RaceController.java
+++ b/backend/src/main/java/com/gridpulse/api/controller/RaceController.java
@@ -2,6 +2,9 @@ package com.gridpulse.api.controller;
 
 import com.gridpulse.api.model.Race;
 import com.gridpulse.api.service.RaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -9,6 +12,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/races")
+@Tag(name = "Races", description = "Race schedule and event information")
 public class RaceController {
 
     private final RaceService raceService;
@@ -18,7 +22,10 @@ public class RaceController {
     }
 
     @GetMapping
-    public List<Race> getRaces(@RequestParam(required = false) String series) {
+    @Operation(summary = "Get all races", description = "Returns all races in the calendar, optionally filtered by series")
+    public List<Race> getRaces(
+            @Parameter(description = "Filter by series key (e.g. f1, f2, f3, fe, indy, wec, wrc)")
+            @RequestParam(required = false) String series) {
         if (series != null && !series.isBlank()) {
             return raceService.getRacesBySeries(series);
         }
@@ -26,7 +33,9 @@ public class RaceController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Race> getRaceById(@PathVariable String id) {
+    @Operation(summary = "Get race by ID", description = "Returns a single race by its MongoDB document ID")
+    public ResponseEntity<Race> getRaceById(
+            @Parameter(description = "Race document ID") @PathVariable String id) {
         return raceService.getRaceById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());

--- a/backend/src/main/java/com/gridpulse/api/controller/SeriesController.java
+++ b/backend/src/main/java/com/gridpulse/api/controller/SeriesController.java
@@ -2,6 +2,8 @@ package com.gridpulse.api.controller;
 
 import com.gridpulse.api.model.Series;
 import com.gridpulse.api.service.SeriesService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,6 +12,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/series")
+@Tag(name = "Series", description = "Racing series metadata")
 public class SeriesController {
 
     private final SeriesService seriesService;
@@ -19,6 +22,7 @@ public class SeriesController {
     }
 
     @GetMapping
+    @Operation(summary = "Get all series", description = "Returns all racing series with their display labels, colors, and session types")
     public List<Series> getAllSeries() {
         return seriesService.getAllSeries();
     }

--- a/backend/src/main/java/com/gridpulse/api/controller/TranslationController.java
+++ b/backend/src/main/java/com/gridpulse/api/controller/TranslationController.java
@@ -1,6 +1,9 @@
 package com.gridpulse.api.controller;
 
 import com.gridpulse.api.service.TranslationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +13,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/translations")
+@Tag(name = "Translations", description = "Internationalization strings")
 public class TranslationController {
 
     private final TranslationService translationService;
@@ -19,7 +23,10 @@ public class TranslationController {
     }
 
     @GetMapping("/{lang}")
-    public Map<String, String> getTranslations(@PathVariable String lang) {
+    @Operation(summary = "Get translations", description = "Returns all i18n key-value pairs for the given language code")
+    public Map<String, String> getTranslations(
+            @Parameter(description = "Language code (e.g. en, fr, es, de, pl, ja, ko)")
+            @PathVariable String lang) {
         return translationService.getTranslations(lang);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,6 +13,12 @@ spring:
 server:
   port: 8080
 
+springdoc:
+  api-docs:
+    path: /api/openapi
+  swagger-ui:
+    path: /api/docs
+
 logging:
   level:
     com.gridpulse: DEBUG


### PR DESCRIPTION
## Summary
- Adds springdoc-openapi-starter-webmvc-ui to auto-generate OpenAPI 3.0 spec from controller annotations
- Swagger UI available at `/api/docs`, raw spec at `/api/openapi`
- OpenAPI annotations on all 4 controllers (Races, Series, News, Translations)
- Spec stays in sync automatically — no manual updates needed when the API changes

Closes #7

## Test plan
- [ ] Verify Swagger UI loads at http://localhost:8080/api/docs
- [ ] Verify OpenAPI JSON at http://localhost:8080/api/openapi
- [ ] Confirm all endpoints are documented with correct parameters and descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)